### PR TITLE
How to use a Regular Account (Selfbot)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-const Discord = require('discord.js');
-const { Client, MessageEmbed, Intents } = require('discord.js');
-const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS] });
+const Discord = require('discord.js-selfbot-v13');
+const { Client, MessageEmbed, Intents } = require('discord.js-selfbot-v13');
+const client = new Client({ checkUpdate: true, });
 require('dotenv').config();
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const Discord = require('discord.js-selfbot-v13');
 const { Client, MessageEmbed, Intents } = require('discord.js-selfbot-v13');
-const client = new Client({ checkUpdate: true, });
+const client = new Client({ checkUpdate: false, });
 require('dotenv').config();
 
 


### PR DESCRIPTION
If you are not using a bot, your only other option is using a regular account (selfbot). 

`discord.js` only allows bot tokens to be connected to the gateway so you are forced to use another package, `discord.js-selfbot-v13`.

### How to install
> `npm install discord.js-selfbot-v13@latest`

### Changes
You will have to change your the classes are destructured and required, replace `discord.js` with `discord.js-selfbot-v13`. 